### PR TITLE
PLFM-9548

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -284,14 +284,16 @@ class AppConfiguration:
 
 if __name__ == '__main__':
 
-  if len(sys.argv) != 5:
-    raise ValueError('Usage: python configuration.py <stack> <instance> <repo-beanstalk-number>,<worker-beanstalk-number>,<portal-beanstalk-number> <aws-cli-profile>, e.g., '+
+  if len(sys.argv) != 4 and len(sys.argv) != 5:
+    raise ValueError('Usage: python configuration.py <stack> <instance> <repo-beanstalk-number>,<worker-beanstalk-number>,<portal-beanstalk-number> [<aws-cli-profile>], e.g., '+
     	'python configuration.py prod 582 582-0,582-0,582-0 myProfile')
 
   stack = sys.argv[1]
   stack_version = sys.argv[2]
   stack_versions_str = sys.argv[3]
-  profile_name = sys.argv[4]
+  profile_name = None
+  if len(sys.argv) == 5:
+  	profile_name = sys.argv[4]
   stack_versions = stack_versions_str.split(',')
   env_keys = ['repo', 'workers', 'portal']
   env_instances = dict(zip(env_keys, stack_versions))

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -466,6 +466,8 @@ class SynapseCloudwatchDashboardStack(Stack):
       repo_version = stack_versions[0]
       workers_version = stack_versions[1]
       portal_version = stack_versions[2]
+      
+      beanstalk_mode=self.node.try_get_context(key='beanstalk_mode')
 
       filescanner_widget = create_filescanner_widget(title='FileScanner', stack_versions=stack_versions)
       opensearch_widget = create_opensearch_widget(title='OpenSearch - searchableDocuments', config=config, stack=stack, stack_versions=stack_versions)
@@ -475,24 +477,28 @@ class SynapseCloudwatchDashboardStack(Stack):
       ses_widget = create_ses_widget(title='SES')
       rds_cpu_widget = create_rds_cpu_utilization_widget(title='RDS - CPU Utilization', stack=stack, stack_versions=stack_versions)
       rds_freestorage_widget = create_rds_free_storage_space_widget(title='RDS - Free Storage Space', stack=stack, stack_versions=stack_versions)
-      repo_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-repo-ec2-instances', [])]
-      cpu_repo_widget = create_ec2_cpu_utilization_widget(title="Repo - CPU Utilization", ec2_instance_ids=repo_ec2_ids)
-      cpu_repo_ecs_widget = create_ecs_cpu_widget("Repo Services" {"ServiceName":f"repo-{stack}-{repo_version}"}})
-      workers_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-workers-ec2-instances', [])]
-      cpu_workers_widget = create_ec2_cpu_utilization_widget(title="Workers - CPU Utilization", ec2_instance_ids=workers_ec2_ids)
-      cpu_workers_ecs_widget = create_ecs_cpu_widget("Worker Services" {"ServiceName":f"repo-{stack}-{workers_version}"}})
-      portal_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-portal-ec2-instances', [])]
-      cpu_portal_widget = create_ec2_cpu_utilization_widget(title="Portal - CPU Utilization", ec2_instance_ids=portal_ec2_ids)
-      cpu_portal_ecs_widget = create_ecs_cpu_widget("Portal Services" {"ServiceName":f"repo-{stack}-{portal_version}"}})
-      network_out_portal_widget = create_ec2_network_out_widget(title="Portal - Network out", ec2_instance_ids=portal_ec2_ids)
-      # TODO create 'network out' widget for portal services
+      if beanstalk_mode:
+        repo_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-repo-ec2-instances', [])]
+        cpu_repo_widget = create_ec2_cpu_utilization_widget(title="Repo - CPU Utilization", ec2_instance_ids=repo_ec2_ids)
+        workers_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-workers-ec2-instances', [])]
+        cpu_workers_widget = create_ec2_cpu_utilization_widget(title="Workers - CPU Utilization", ec2_instance_ids=workers_ec2_ids)
+        portal_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-portal-ec2-instances', [])]
+        cpu_portal_widget = create_ec2_cpu_utilization_widget(title="Portal - CPU Utilization", ec2_instance_ids=portal_ec2_ids)
+        network_out_portal_widget = create_ec2_network_out_widget(title="Portal - Network out", ec2_instance_ids=portal_ec2_ids)
+      else:
+        cpu_repo_widget = create_ecs_cpu_widget("Repo Services", {"ServiceName":f"repo-{stack}-{repo_version}"})
+        cpu_workers_widget = create_ecs_cpu_widget("Worker Services", {"ServiceName":f"repo-{stack}-{workers_version}"})
+        cpu_portal_widget = create_ecs_cpu_widget("Portal Services", {"ServiceName":f"repo-{stack}-{portal_version}"})
+        # TODO create 'network out' widget for portal services
       repo_memory_widget = create_memory_widget(title='Repo - Memory used', config=config, stack_versions=stack_versions, environment='Repository')
       workers_memory_widget = create_memory_widget(title='Workers - Memory used', config=config, stack_versions=stack_versions, environment='Workers')
       workers_jobs_completed_widget = create_worker_stats_widget(title="Workers stats - Jobs completed", config=config, stack_versions=stack_versions, metric_name='Completed Job Count')
       workers_pc_time_widget = create_worker_stats_widget(title="Workers stats - % time running", config=config, stack_versions=stack_versions, metric_name='% Time Running')
       workers_cumulative_time_widget = create_worker_stats_widget(title="Workers stats - Cumulative time", config=config, stack_versions=stack_versions, metric_name='Cumulative runtime')
-      repo_alb_rtime_widget2 = create_repo_alb_response_widget_v2(title='Repo ALB response time', config=config, stack_versions=stack_versions)
-      repo_ecs_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, repo_version)
+      if beanstalk_mode:
+        repo_alb_rtime_widget2 = create_repo_alb_response_widget_v2(title='Repo ALB response time', config=config, stack_versions=stack_versions)
+      else:
+        repo_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, repo_version)
       registry_ecs_cpu_widget = create_registry_ecs_cpu_widget_v2(stack)
       registry_ecs_network_widget = create_registry_ecs_network_widget_v2(stack)
       rds_read_throughput_widget = create_rds_read_throughput_widget(title="RDS Read Throughput", stack=stack, stack_versions=stack_versions)
@@ -503,15 +509,15 @@ class SynapseCloudwatchDashboardStack(Stack):
       rds_write_iops_widget = create_rds_write_iops_widget(title="RDS Write Iops", stack=stack, stack_versions=stack_versions)
 
       dashboard.add_widgets(cpu_repo_widget)
-      dashboard.add_widgets(cpu_repo_ecs_widget)
       dashboard.add_widgets(cpu_workers_widget)
-      dashboard.add_widgets(cpu_workers_ecs_widget)
       dashboard.add_widgets(rds_cpu_widget)
       dashboard.add_widgets(rds_freestorage_widget)
       dashboard.add_widgets(cpu_portal_widget)
-      dashboard.add_widgets(cpu_portal_ecs_widget)
-      dashboard.add_widgets(network_out_portal_widget)
-      # TODO display 'network out' widget for portal services
+      if beanstalk_mode:
+        dashboard.add_widgets(network_out_portal_widget)
+      else:
+        pass
+        # TODO display 'network out' widget for portal services
       dashboard.add_widgets(registry_ecs_cpu_widget, registry_ecs_network_widget)
       dashboard.add_widgets(repo_memory_widget)
       dashboard.add_widgets(workers_memory_widget)
@@ -522,7 +528,6 @@ class SynapseCloudwatchDashboardStack(Stack):
       dashboard.add_widgets(workers_cumulative_time_widget)
       dashboard.add_widgets(query_perf_widget)
       dashboard.add_widgets(repo_alb_rtime_widget2)
-      dashboard.add_widgets(repo_ecs_alb_rtime_widget2)
       dashboard.add_widgets(ses_widget)
       dashboard.add_widgets(filescanner_widget)
       dashboard.add_widgets(opensearch_widget)

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -376,10 +376,10 @@ def create_registry_ecs_cpu_widget_v2(stack):
   widget = create_ecs_cpu_widget("Docker Registry", DIMENSIONS)
   return widget
 
-def create_ecs_cpu_widget(title, dimensions):
+def create_ecs_cpu_widget(title, dimensions): # TODO pass in list of dimensions
   # Prefer ECS/ContainerInsights metrics if available
   # Container Insights metrics: CpuUtilized, CpuReserved, etc.
-  cpu_utilized = cw.Metric(
+  cpu_utilized = cw.Metric( # TODO make a pair of metrics for each entry in the dimensions list
     namespace="ECS/ContainerInsights",
     metric_name="CpuUtilized",
     dimensions_map=dimensions,
@@ -393,7 +393,7 @@ def create_ecs_cpu_widget(title, dimensions):
     statistic="Average",
     region="us-east-1"
   )
-  metrics = [cpu_utilized, cpu_reserved]
+  metrics = [cpu_utilized, cpu_reserved] # TODO add all metrics here
   widget = cw.GraphWidget(
     title=title+" - CPU Utilization vs Reserved",
     width=12,
@@ -436,6 +436,12 @@ def create_registry_ecs_network_widget_v2(stack):
                           left=metrics)
   return widget
 
+# stack: dev or prod
+# service: repo, workers, or portal
+# version: e.g., 582
+# Note: assumes beanstalk number of 0
+def create_ecs_dimensions(stack, service, version):
+	return {"ClusterName":f"synapse-{stack}-{version}.", "ServiceName":f"{service}-{stack}-{version}-0"}
 
 class SynapseCloudwatchDashboardStack(Stack):
 
@@ -466,20 +472,18 @@ class SynapseCloudwatchDashboardStack(Stack):
       
       beanstalk_numbers_str = self.node.try_get_context(key='beanstalk_numbers')
       
-      if beanstalk_numbers_str is None:
-        raise ValueError('No beanstalk numbers specified')
+      #if beanstalk_numbers_str is None:
+      #  raise ValueError('No beanstalk numbers specified')
         
-      beanstalk_numbers = beanstalk_numbers_str.split(',')
-      repo_beanstalk_number = beanstalk_numbers[0]
-      workers_beanstalk_number = beanstalk_numbers[1]
-      portal_beanstalk_number = beanstalk_numbers[2]
+      #beanstalk_numbers = beanstalk_numbers_str.split(',')
+      #repo_beanstalk_number = beanstalk_numbers[0]
+      #workers_beanstalk_number = beanstalk_numbers[1]
+      #portal_beanstalk_number = beanstalk_numbers[2]
       
       
       beanstalk_mode=self.node.try_get_context(key='beanstalk_mode')
       beanstalk_mode=ast.literal_eval(beanstalk_mode) 
       
-      print(f"stack: {stack} stack_versions: {stack_versions} beanstalk_numbers: {beanstalk_numbers_str} beanstalk_mode: {beanstalk_mode}")
-
       filescanner_widget = create_filescanner_widget(title='FileScanner', stack_versions=stack_versions)
       opensearch_widget = create_opensearch_widget(title='OpenSearch - searchableDocuments', config=config, stack=stack, stack_versions=stack_versions)
       repo_active_connections_widget = create_repo_active_connections_widget(title='Repo-Active-Connections', stack_versions=stack_versions)
@@ -497,9 +501,9 @@ class SynapseCloudwatchDashboardStack(Stack):
         cpu_portal_widget = create_ec2_cpu_utilization_widget(title="Portal - CPU Utilization", ec2_instance_ids=portal_ec2_ids)
         network_out_portal_widget = create_ec2_network_out_widget(title="Portal - Network out", ec2_instance_ids=portal_ec2_ids)
       else:
-        cpu_repo_widget = create_ecs_cpu_widget("Repo Services", {"ServiceName":f"repo-{stack}-{repo_beanstalk_number}"})
-        cpu_workers_widget = create_ecs_cpu_widget("Worker Services", {"ServiceName":f"repo-{stack}-{workers_beanstalk_number}"})
-        cpu_portal_widget = create_ecs_cpu_widget("Portal Services", {"ServiceName":f"repo-{stack}-{portal_beanstalk_number}"})
+        cpu_repo_widget = create_ecs_cpu_widget("Repo Services", create_ecs_dimensions(stack, 'repo', stack_versions[0]))
+        cpu_workers_widget = create_ecs_cpu_widget("Worker Services", create_ecs_dimensions(stack, 'workers', stack_versions[0]))
+        cpu_portal_widget = create_ecs_cpu_widget("Portal Services", create_ecs_dimensions(stack, 'portal', stack_versions[0]))
         # TODO create 'network out' widget for portal services
       repo_memory_widget = create_memory_widget(title='Repo - Memory used', config=config, stack_versions=stack_versions, environment='Repository')
       workers_memory_widget = create_memory_widget(title='Workers - Memory used', config=config, stack_versions=stack_versions, environment='Workers')
@@ -509,7 +513,7 @@ class SynapseCloudwatchDashboardStack(Stack):
       if beanstalk_mode:
         repo_alb_rtime_widget2 = create_repo_alb_response_widget_v2(title='Repo ALB response time', config=config, stack_versions=stack_versions)
       else:
-        repo_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, repo_beanstalk_number)
+        repo_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, stack_versions[0]+"-0")
       registry_ecs_cpu_widget = create_registry_ecs_cpu_widget_v2(stack)
       registry_ecs_network_widget = create_registry_ecs_network_widget_v2(stack)
       rds_read_throughput_widget = create_rds_read_throughput_widget(title="RDS Read Throughput", stack=stack, stack_versions=stack_versions)

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -571,6 +571,7 @@ class SynapseCloudwatchDashboardStack(Stack):
 
     def version_to_lb_name_map(self, service, stack, stack_versions):
       next_token=None
+      result = {}
       while (True):
         if next_token==None:
           response = self.cw_client.list_metrics(
@@ -581,7 +582,6 @@ class SynapseCloudwatchDashboardStack(Stack):
             Namespace="AWS/ApplicationELB", 
             MetricName="TargetResponseTime",
             NextToken=next_token)
-       result = {}
         for metric in response.get('Metrics',[]):
           for dimension in metric.get('Dimensions',[]):
             if "LoadBalancer"==dimension.get('Name',None):

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -572,11 +572,16 @@ class SynapseCloudwatchDashboardStack(Stack):
     def version_to_lb_name_map(self, service, stack, stack_versions):
       next_token=None
       while (True):
-        response = self.cw_client.list_metrics(
-          Namespace="AWS/ApplicationELB", 
-          MetricName="TargetResponseTime",
-          NextToken=next_token)
-        result = {}
+        if next_token==None:
+          response = self.cw_client.list_metrics(
+            Namespace="AWS/ApplicationELB", 
+            MetricName="TargetResponseTime")
+        else:
+           response = self.cw_client.list_metrics(
+            Namespace="AWS/ApplicationELB", 
+            MetricName="TargetResponseTime",
+            NextToken=next_token)
+       result = {}
         for metric in response.get('Metrics',[]):
           for dimension in metric.get('Dimensions',[]):
             if "LoadBalancer"==dimension.get('Name',None):

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -441,7 +441,7 @@ def create_registry_ecs_network_widget_v2(stack):
 # version: e.g., 582
 # Note: assumes beanstalk number of 0
 def create_ecs_dimensions(stack, service, version):
-	return {"ClusterName":f"synapse-{stack}-{version}.", "ServiceName":f"{service}-{stack}-{version}-0"}
+	return {"ClusterName":f"synapse-{stack}-{version}", "ServiceName":f"{service}-{stack}-{version}-0"}
 
 class SynapseCloudwatchDashboardStack(Stack):
 

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -326,13 +326,13 @@ def create_repo_alb_response_widget_v2(title, config, stack_versions):
 
   return widget
 
-def create_repo_ecs_alb_response_widget_v2(title, stack, repo_version):
+def create_repo_ecs_alb_response_widget_v2(title, stack, repo_beanstalk_number):
   metrics = []
   
-  # The LB name is repo-{stack}-{repo_version}
-  # but the metric is like LoadBalancer=app/repo-{stack}-{repo_version}/bfe76ada85368a80
+  # The LB name is repo-{stack}-{repo_beanstalk_number}
+  # but the metric is like LoadBalancer=app/repo-{stack}-{repo_beanstalk_number}/bfe76ada85368a80
   # so we need to know the suffix; the following is wrong:
-  dv = f"repo-{stack}-{repo_version}"
+  dv = f"repo-{stack}-{repo_beanstalk_number}"
 
   metric1 = cw.Metric(
       namespace='AWS/ApplicationELB',
@@ -340,7 +340,7 @@ def create_repo_ecs_alb_response_widget_v2(title, stack, repo_version):
       dimensions_map={'LoadBalancer': dv},
       period=Duration.seconds(300),
       statistic='Average',
-      label=f'{repo_version} - Average'
+      label=f'{repo_beanstalk_number} - Average'
   )
   metric2 = cw.Metric(
       namespace='AWS/ApplicationELB',
@@ -348,7 +348,7 @@ def create_repo_ecs_alb_response_widget_v2(title, stack, repo_version):
       dimensions_map={'LoadBalancer': dv},
       period=Duration.seconds(300),
       statistic='p95',
-      label=f'{repo_version} - p95'
+      label=f'{repo_beanstalk_number} - p95'
   )
   metrics.append(metric1)
   metrics.append(metric2)
@@ -463,9 +463,16 @@ class SynapseCloudwatchDashboardStack(Stack):
 
       config = init_config(stack=stack, profile_name=profile_name)
       
-      repo_version = stack_versions[0]
-      workers_version = stack_versions[1]
-      portal_version = stack_versions[2]
+      beanstalk_numbers_str = self.node.try_get_context(key='beanstalk_numbers')
+      
+      if beanstalk_numbers_str is None:
+        raise ValueError('No beanstalk numbers specified')
+        
+      beanstalk_numbers = beanstalk_numbers_str.split(',')
+      repo_beanstalk_number = beanstalk_numbers[0]
+      workers_beanstalk_number = beanstalk_numbers[1]
+      portal_beanstalk_number = beanstalk_numbers[2]
+      
       
       beanstalk_mode=self.node.try_get_context(key='beanstalk_mode')
 
@@ -486,9 +493,9 @@ class SynapseCloudwatchDashboardStack(Stack):
         cpu_portal_widget = create_ec2_cpu_utilization_widget(title="Portal - CPU Utilization", ec2_instance_ids=portal_ec2_ids)
         network_out_portal_widget = create_ec2_network_out_widget(title="Portal - Network out", ec2_instance_ids=portal_ec2_ids)
       else:
-        cpu_repo_widget = create_ecs_cpu_widget("Repo Services", {"ServiceName":f"repo-{stack}-{repo_version}"})
-        cpu_workers_widget = create_ecs_cpu_widget("Worker Services", {"ServiceName":f"repo-{stack}-{workers_version}"})
-        cpu_portal_widget = create_ecs_cpu_widget("Portal Services", {"ServiceName":f"repo-{stack}-{portal_version}"})
+        cpu_repo_widget = create_ecs_cpu_widget("Repo Services", {"ServiceName":f"repo-{stack}-{repo_beanstalk_number}"})
+        cpu_workers_widget = create_ecs_cpu_widget("Worker Services", {"ServiceName":f"repo-{stack}-{workers_beanstalk_number}"})
+        cpu_portal_widget = create_ecs_cpu_widget("Portal Services", {"ServiceName":f"repo-{stack}-{portal_beanstalk_number}"})
         # TODO create 'network out' widget for portal services
       repo_memory_widget = create_memory_widget(title='Repo - Memory used', config=config, stack_versions=stack_versions, environment='Repository')
       workers_memory_widget = create_memory_widget(title='Workers - Memory used', config=config, stack_versions=stack_versions, environment='Workers')
@@ -498,7 +505,7 @@ class SynapseCloudwatchDashboardStack(Stack):
       if beanstalk_mode:
         repo_alb_rtime_widget2 = create_repo_alb_response_widget_v2(title='Repo ALB response time', config=config, stack_versions=stack_versions)
       else:
-        repo_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, repo_version)
+        repo_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, repo_beanstalk_number)
       registry_ecs_cpu_widget = create_registry_ecs_cpu_widget_v2(stack)
       registry_ecs_network_widget = create_registry_ecs_network_widget_v2(stack)
       rds_read_throughput_widget = create_rds_read_throughput_widget(title="RDS Read Throughput", stack=stack, stack_versions=stack_versions)

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -8,15 +8,16 @@ from aws_cdk import (
 from constructs import Construct
 import ast
 
-
-def init_config(stack, profile_name):
-  BUCKET_NAME = f'{stack}.cloudwatch.metrics.sagebase.org'
-  FILE_KEY = f'{stack}_cw_configuration.json'
+def get_aws_provider(profile_name):
   if profile_name:
     session = boto3.Session(profile_name=profile_name, region_name='us-east-1')
   else:
     session = boto3.Session(region_name='us-east-1')
-  aws_provider = AwsProvider(session=session)
+  return AwsProvider(session=session)
+
+def init_config(stack, aws_provider):
+  BUCKET_NAME = f'{stack}.cloudwatch.metrics.sagebase.org'
+  FILE_KEY = f'{stack}_cw_configuration.json'
   s3_client = aws_provider.get_client(client_type='s3')
   configuration_provider = ConfigurationProvider(s3_client=s3_client, bucket_name=BUCKET_NAME, file_key=FILE_KEY)
   config = configuration_provider.load_raw_configuration()
@@ -327,32 +328,31 @@ def create_repo_alb_response_widget_v2(title, config, stack_versions):
 
   return widget
 
-def create_repo_ecs_alb_response_widget_v2(title, stack, repo_beanstalk_number):
+def create_repo_ecs_alb_response_widget_v2(title, stack, version_lb_name_map):
   metrics = []
-  
-  # The LB name is repo-{stack}-{repo_beanstalk_number}
-  # but the metric is like LoadBalancer=app/repo-{stack}-{repo_beanstalk_number}/bfe76ada85368a80
-  # so we need to know the suffix; the following is wrong:
-  dv = f"repo-{stack}-{repo_beanstalk_number}"
+  print(f"Size of version_lb_name_map is {len(version_lb_name_map)}")
+  for stack_version in version_lb_name_map:
+    lb_name=version_lb_name_map[stack_version]
+    print(f"For stack version {stack_version}, load balancer name is {lb_name}.")
 
-  metric1 = cw.Metric(
+    metric1 = cw.Metric(
       namespace='AWS/ApplicationELB',
       metric_name='TargetResponseTime',
-      dimensions_map={'LoadBalancer': dv},
+      dimensions_map={'LoadBalancer': lb_name},
       period=Duration.seconds(300),
       statistic='Average',
-      label=f'{repo_beanstalk_number} - Average'
-  )
-  metric2 = cw.Metric(
+      label=f'{stack_version}-0 - Average'
+    )
+    metric2 = cw.Metric(
       namespace='AWS/ApplicationELB',
       metric_name='TargetResponseTime',
-      dimensions_map={'LoadBalancer': dv},
+      dimensions_map={'LoadBalancer': lb_name},
       period=Duration.seconds(300),
       statistic='p95',
-      label=f'{repo_beanstalk_number} - p95'
-  )
-  metrics.append(metric1)
-  metrics.append(metric2)
+      label=f'{stack_version}-0 - p95'
+    )
+    metrics.append(metric1)
+    metrics.append(metric2)
 
   widget = cw.GraphWidget(
     title=title,
@@ -373,30 +373,35 @@ def create_registry_ecs_cpu_widget_v2(stack):
     "ServiceName": "registry-dev-DockerFargateStack-registrydevService896F8BD4-GC9L2E0ibdbP",
     "ClusterName": "registry-dev-DockerFargateStack-registrydevDockerFargateStackCluster83B3D290-XhfK58ULXLP4",
   }
-  widget = create_ecs_cpu_widget("Docker Registry", DIMENSIONS)
+  widget = create_ecs_cpu_widget("Docker Registry", [{"dimensions":DIMENSIONS,"label":"Docker Registry"}])
   return widget
 
-def create_ecs_cpu_widget(title, dimensions): # TODO pass in list of dimensions
+def create_ecs_cpu_widget(title, dimensions_and_labels_list, width=12):
   # Prefer ECS/ContainerInsights metrics if available
   # Container Insights metrics: CpuUtilized, CpuReserved, etc.
-  cpu_utilized = cw.Metric( # TODO make a pair of metrics for each entry in the dimensions list
-    namespace="ECS/ContainerInsights",
-    metric_name="CpuUtilized",
-    dimensions_map=dimensions,
-    statistic="Average",
-    region="us-east-1"
-  )
-  cpu_reserved = cw.Metric(
-    namespace="ECS/ContainerInsights",
-    metric_name="CpuReserved",
-    dimensions_map=dimensions,
-    statistic="Average",
-    region="us-east-1"
-  )
-  metrics = [cpu_utilized, cpu_reserved] # TODO add all metrics here
+  
+  metrics = []
+  for dimensions_and_label in dimensions_and_labels_list:
+    cpu_utilized = cw.Metric(
+      namespace="ECS/ContainerInsights",
+      metric_name="CpuUtilized",
+      label=f"CpuUtilized-{dimensions_and_label['label']}",
+      dimensions_map=dimensions_and_label["dimensions"],
+      statistic="Average",
+      region="us-east-1"
+    )
+    cpu_reserved = cw.Metric(
+      namespace="ECS/ContainerInsights",
+      metric_name="CpuReserved",
+      label=f"CpuReserved-{dimensions_and_label['label']}",
+      dimensions_map=dimensions_and_label["dimensions"],
+      statistic="Average",
+      region="us-east-1"
+    )
+    metrics.extend([cpu_utilized, cpu_reserved])
   widget = cw.GraphWidget(
     title=title+" - CPU Utilization vs Reserved",
-    width=12,
+    width=width,
     height=4,
     view=cw.GraphWidgetView.TIME_SERIES,
     stacked=False,
@@ -414,34 +419,33 @@ def create_registry_ecs_network_widget_v2(stack):
     "ServiceName": "registry-dev-DockerFargateStack-registrydevService896F8BD4-GC9L2E0ibdbP",
     "ClusterName": "registry-dev-DockerFargateStack-registrydevDockerFargateStackCluster83B3D290-XhfK58ULXLP4",
   }
-
-  # Network bandwidth metrics
-  network_rx = cw.Metric(
-    namespace="ECS/ContainerInsights",
-    metric_name="NetworkRxBytes",
-    dimensions_map=DIMENSIONS,
-    statistic="Sum",
-    region="us-east-1"
-  )
-  network_tx = cw.Metric(
-    namespace="ECS/ContainerInsights",
-    metric_name="NetworkTxBytes",
-    dimensions_map=DIMENSIONS,
-    statistic="Sum",
-    region="us-east-1"
-  )
-  metrics = [network_rx, network_tx]
-  widget = cw.GraphWidget(title="Registry - Network utilization", width=12, height=4, view=cw.GraphWidgetView.TIME_SERIES,
+  return create_ecs_network_out_widget([{"dimensions":DIMENSIONS,"label":"Docker Registry"}], title="Docker Registry - Network utilization")
+  
+def create_ecs_network_out_widget(dimensions_and_labels_list, title, width=12):
+  metrics = []
+  for dimensions_and_label in dimensions_and_labels_list:
+    # Network bandwidth metrics
+    network_rx = cw.Metric(
+      namespace="ECS/ContainerInsights",
+      metric_name="NetworkRxBytes",
+      label=f"NetworkRxBytes-{dimensions_and_label['label']}",
+      dimensions_map=dimensions_and_label["dimensions"],
+      statistic="Sum",
+      region="us-east-1"
+    )
+    network_tx = cw.Metric(
+      namespace="ECS/ContainerInsights",
+      metric_name="NetworkTxBytes",
+      label=f"NetworkTxBytes-{dimensions_and_label['label']}",
+      dimensions_map=dimensions_and_label["dimensions"],
+      statistic="Sum",
+      region="us-east-1"
+    )
+    metrics.extend([network_rx, network_tx])
+  widget = cw.GraphWidget(title=title, width=width, height=4, view=cw.GraphWidgetView.TIME_SERIES,
                           stacked=False, set_period_to_time_range=True,
                           left=metrics)
   return widget
-
-# stack: dev or prod
-# service: repo, workers, or portal
-# version: e.g., 582
-# Note: assumes beanstalk number of 0
-def create_ecs_dimensions(stack, service, version):
-	return {"ClusterName":f"synapse-{stack}-{version}", "ServiceName":f"{service}-{stack}-{version}-0"}
 
 class SynapseCloudwatchDashboardStack(Stack):
 
@@ -468,19 +472,9 @@ class SynapseCloudwatchDashboardStack(Stack):
         default_interval=Duration.days(35),
       )
 
-      config = init_config(stack=stack, profile_name=profile_name)
-      
-      beanstalk_numbers_str = self.node.try_get_context(key='beanstalk_numbers')
-      
-      #if beanstalk_numbers_str is None:
-      #  raise ValueError('No beanstalk numbers specified')
-        
-      #beanstalk_numbers = beanstalk_numbers_str.split(',')
-      #repo_beanstalk_number = beanstalk_numbers[0]
-      #workers_beanstalk_number = beanstalk_numbers[1]
-      #portal_beanstalk_number = beanstalk_numbers[2]
-      
-      
+      aws_provider = get_aws_provider(profile_name)
+      config = init_config(stack, aws_provider)
+      self.cw_client = aws_provider.get_client(client_type='cloudwatch')
       beanstalk_mode=self.node.try_get_context(key='beanstalk_mode')
       beanstalk_mode=ast.literal_eval(beanstalk_mode) 
       
@@ -501,10 +495,10 @@ class SynapseCloudwatchDashboardStack(Stack):
         cpu_portal_widget = create_ec2_cpu_utilization_widget(title="Portal - CPU Utilization", ec2_instance_ids=portal_ec2_ids)
         network_out_portal_widget = create_ec2_network_out_widget(title="Portal - Network out", ec2_instance_ids=portal_ec2_ids)
       else:
-        cpu_repo_widget = create_ecs_cpu_widget("Repo Services", create_ecs_dimensions(stack, 'repo', stack_versions[0]))
-        cpu_workers_widget = create_ecs_cpu_widget("Worker Services", create_ecs_dimensions(stack, 'workers', stack_versions[0]))
-        cpu_portal_widget = create_ecs_cpu_widget("Portal Services", create_ecs_dimensions(stack, 'portal', stack_versions[0]))
-        # TODO create 'network out' widget for portal services
+        cpu_repo_widget = create_ecs_cpu_widget("Repo Services", self.create_ecs_dimensions(stack, 'repo', stack_versions), width=24)
+        cpu_workers_widget = create_ecs_cpu_widget("Worker Services", self.create_ecs_dimensions(stack, 'workers', stack_versions), width=24)
+        cpu_portal_widget = create_ecs_cpu_widget("Portal Services", self.create_ecs_dimensions(stack, 'portal', stack_versions), width=24)
+        network_out_portal_widget = create_ecs_network_out_widget(self.create_ecs_dimensions(stack, 'portal', stack_versions), title="Portal - Network out", width=24)
       repo_memory_widget = create_memory_widget(title='Repo - Memory used', config=config, stack_versions=stack_versions, environment='Repository')
       workers_memory_widget = create_memory_widget(title='Workers - Memory used', config=config, stack_versions=stack_versions, environment='Workers')
       workers_jobs_completed_widget = create_worker_stats_widget(title="Workers stats - Jobs completed", config=config, stack_versions=stack_versions, metric_name='Completed Job Count')
@@ -513,7 +507,7 @@ class SynapseCloudwatchDashboardStack(Stack):
       if beanstalk_mode:
         repo_alb_rtime_widget2 = create_repo_alb_response_widget_v2(title='Repo ALB response time', config=config, stack_versions=stack_versions)
       else:
-        repo_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, stack_versions[0]+"-0")
+        repo_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, self.version_to_lb_name_map("repo", stack, stack_versions))
       registry_ecs_cpu_widget = create_registry_ecs_cpu_widget_v2(stack)
       registry_ecs_network_widget = create_registry_ecs_network_widget_v2(stack)
       rds_read_throughput_widget = create_rds_read_throughput_widget(title="RDS Read Throughput", stack=stack, stack_versions=stack_versions)
@@ -528,11 +522,7 @@ class SynapseCloudwatchDashboardStack(Stack):
       dashboard.add_widgets(rds_cpu_widget)
       dashboard.add_widgets(rds_freestorage_widget)
       dashboard.add_widgets(cpu_portal_widget)
-      if beanstalk_mode:
-        dashboard.add_widgets(network_out_portal_widget)
-      else:
-        pass
-        # TODO display 'network out' widget for portal services
+      dashboard.add_widgets(network_out_portal_widget)
       dashboard.add_widgets(registry_ecs_cpu_widget, registry_ecs_network_widget)
       dashboard.add_widgets(repo_memory_widget)
       dashboard.add_widgets(workers_memory_widget)
@@ -550,4 +540,47 @@ class SynapseCloudwatchDashboardStack(Stack):
       dashboard.add_widgets(rds_read_latency_widget, rds_write_latency_widget)
       dashboard.add_widgets(rds_read_iops_widget, rds_write_iops_widget)
 
+    def get_ecs_task_ids(self, service_name):
+      response = self.cw_client.list_metrics(
+        Namespace="ECS/ContainerInsights", 
+        MetricName="TaskCpuUtilization",
+        Dimensions=[{"Name":"ServiceName","Value":service_name}])
+      result=set()
+      for metric in response.get('Metrics',[]):
+        for dimension in metric.get('Dimensions',[]):
+          if "TaskId"==dimension.get('Name',None):
+            result.add(dimension['Value'])
+      return result
+
+    # stack: dev or prod
+    # service: repo, workers, or portal
+    # versions: e.g., [582,583]
+    # Note: assumes beanstalk number of 0
+    def create_ecs_dimensions(self, stack, service, versions):
+    	result = []
+    	for version in versions:
+    		service_name=f"{service}-{stack}-{version}-0"
+    		for task_id in self.get_ecs_task_ids(service_name):
+    			dimensions={
+    				"ClusterName":f"synapse-{stack}-{version}", 
+    				"ServiceName":service_name,
+    				"TaskId":task_id}
+    			label=f"{version}-{task_id}"
+    			result.append({"dimensions":dimensions, "label":label})
+    	return result
+
+    def version_to_lb_name_map(self, service, stack, stack_versions):
+      response = self.cw_client.list_metrics(
+        Namespace="AWS/ApplicationELB", 
+        MetricName="TargetResponseTime")
+      result = {}
+      # TODO paginate
+      for metric in response.get('Metrics',[]):
+        for dimension in metric.get('Dimensions',[]):
+          if "LoadBalancer"==dimension.get('Name',None):
+            lb_name=dimension['Value']
+            for stack_version in stack_versions:
+              if lb_name.startswith(f"app/{service}-{stack}-{stack_version}-0"):
+                result[stack_version]=lb_name
+      return result
 

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -570,17 +570,22 @@ class SynapseCloudwatchDashboardStack(Stack):
     	return result
 
     def version_to_lb_name_map(self, service, stack, stack_versions):
-      response = self.cw_client.list_metrics(
-        Namespace="AWS/ApplicationELB", 
-        MetricName="TargetResponseTime")
-      result = {}
-      # TODO paginate
-      for metric in response.get('Metrics',[]):
-        for dimension in metric.get('Dimensions',[]):
-          if "LoadBalancer"==dimension.get('Name',None):
-            lb_name=dimension['Value']
-            for stack_version in stack_versions:
-              if lb_name.startswith(f"app/{service}-{stack}-{stack_version}-0"):
-                result[stack_version]=lb_name
+      next_token=None
+      while (True):
+        response = self.cw_client.list_metrics(
+          Namespace="AWS/ApplicationELB", 
+          MetricName="TargetResponseTime",
+          NextToken=next_token)
+        result = {}
+        for metric in response.get('Metrics',[]):
+          for dimension in metric.get('Dimensions',[]):
+            if "LoadBalancer"==dimension.get('Name',None):
+              lb_name=dimension['Value']
+              for stack_version in stack_versions:
+                if lb_name.startswith(f"app/{service}-{stack}-{stack_version}-0"):
+                  result[stack_version]=lb_name
+        next_token = response.get("NextToken",None)
+        if next_token is None:
+          break
       return result
 

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -6,6 +6,7 @@ from aws_cdk import (
     aws_cloudwatch as cw
 )
 from constructs import Construct
+import ast
 
 
 def init_config(stack, profile_name):
@@ -475,6 +476,7 @@ class SynapseCloudwatchDashboardStack(Stack):
       
       
       beanstalk_mode=self.node.try_get_context(key='beanstalk_mode')
+      beanstalk_mode=ast.literal_eval(beanstalk_mode) 
       
       print(f"stack: {stack} stack_versions: {stack_versions} beanstalk_numbers: {beanstalk_numbers_str} beanstalk_mode: {beanstalk_mode}")
 

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -475,6 +475,8 @@ class SynapseCloudwatchDashboardStack(Stack):
       
       
       beanstalk_mode=self.node.try_get_context(key='beanstalk_mode')
+      
+      print(f"stack: {stack} stack_versions: {stack_versions} beanstalk_numbers: {beanstalk_numbers_str} beanstalk_mode: {beanstalk_mode}")
 
       filescanner_widget = create_filescanner_widget(title='FileScanner', stack_versions=stack_versions)
       opensearch_widget = create_opensearch_widget(title='OpenSearch - searchableDocuments', config=config, stack=stack, stack_versions=stack_versions)

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -326,7 +326,45 @@ def create_repo_alb_response_widget_v2(title, config, stack_versions):
 
   return widget
 
-def create_docker_cpu_widget_v2(stack):
+def create_repo_ecs_alb_response_widget_v2(title, stack, repo_version):
+  metrics = []
+  
+  # The LB name is repo-{stack}-{repo_version}
+  # but the metric is like LoadBalancer=app/repo-{stack}-{repo_version}/bfe76ada85368a80
+  # so we need to know the suffix; the following is wrong:
+  dv = f"repo-{stack}-{repo_version}"
+
+  metric1 = cw.Metric(
+      namespace='AWS/ApplicationELB',
+      metric_name='TargetResponseTime',
+      dimensions_map={'LoadBalancer': dv},
+      period=Duration.seconds(300),
+      statistic='Average',
+      label=f'{repo_version} - Average'
+  )
+  metric2 = cw.Metric(
+      namespace='AWS/ApplicationELB',
+      metric_name='TargetResponseTime',
+      dimensions_map={'LoadBalancer': dv},
+      period=Duration.seconds(300),
+      statistic='p95',
+      label=f'{repo_version} - p95'
+  )
+  metrics.append(metric1)
+  metrics.append(metric2)
+
+  widget = cw.GraphWidget(
+    title=title,
+    width=24,
+    height=4,
+    view=cw.GraphWidgetView.TIME_SERIES,
+    stacked=False,
+    set_period_to_time_range=True,
+    left=metrics
+  )
+  return widget
+
+def create_registry_ecs_cpu_widget_v2(stack):
   DIMENSIONS = {
     "ServiceName": "registry-prod-DockerFargateStack-registryprodServiceAFB525D2-UYnZR5jh3Dqx",
     "ClusterName": "registry-prod-DockerFargateStack-registryprodDockerFargateStackCluster47F74A14-MGrtooDf35X9",
@@ -334,10 +372,10 @@ def create_docker_cpu_widget_v2(stack):
     "ServiceName": "registry-dev-DockerFargateStack-registrydevService896F8BD4-GC9L2E0ibdbP",
     "ClusterName": "registry-dev-DockerFargateStack-registrydevDockerFargateStackCluster83B3D290-XhfK58ULXLP4",
   }
-  widget = create_ecs_cpu_widget(DIMENSIONS)
+  widget = create_ecs_cpu_widget("Docker Registry", DIMENSIONS)
   return widget
 
-def create_ecs_cpu_widget(dimensions):
+def create_ecs_cpu_widget(title, dimensions):
   # Prefer ECS/ContainerInsights metrics if available
   # Container Insights metrics: CpuUtilized, CpuReserved, etc.
   cpu_utilized = cw.Metric(
@@ -356,7 +394,7 @@ def create_ecs_cpu_widget(dimensions):
   )
   metrics = [cpu_utilized, cpu_reserved]
   widget = cw.GraphWidget(
-    title="ECS Container Insights - CPU Utilization vs Reserved",
+    title=title+" - CPU Utilization vs Reserved",
     width=12,
     height=4,
     view=cw.GraphWidgetView.TIME_SERIES,
@@ -367,7 +405,7 @@ def create_ecs_cpu_widget(dimensions):
   return widget
 
 
-def create_docker_network_widget_v2(stack):
+def create_registry_ecs_network_widget_v2(stack):
   DIMENSIONS = {
     "ServiceName": "registry-prod-DockerFargateStack-registryprodServiceAFB525D2-UYnZR5jh3Dqx",
     "ClusterName": "registry-prod-DockerFargateStack-registryprodDockerFargateStackCluster47F74A14-MGrtooDf35X9",
@@ -392,7 +430,7 @@ def create_docker_network_widget_v2(stack):
     region="us-east-1"
   )
   metrics = [network_rx, network_tx]
-  widget = cw.GraphWidget(title="Docker - Network utilization", width=12, height=4, view=cw.GraphWidgetView.TIME_SERIES,
+  widget = cw.GraphWidget(title="Registry - Network utilization", width=12, height=4, view=cw.GraphWidgetView.TIME_SERIES,
                           stacked=False, set_period_to_time_range=True,
                           left=metrics)
   return widget
@@ -424,6 +462,10 @@ class SynapseCloudwatchDashboardStack(Stack):
       )
 
       config = init_config(stack=stack, profile_name=profile_name)
+      
+      repo_version = stack_versions[0]
+      workers_version = stack_versions[1]
+      portal_version = stack_versions[2]
 
       filescanner_widget = create_filescanner_widget(title='FileScanner', stack_versions=stack_versions)
       opensearch_widget = create_opensearch_widget(title='OpenSearch - searchableDocuments', config=config, stack=stack, stack_versions=stack_versions)
@@ -435,19 +477,24 @@ class SynapseCloudwatchDashboardStack(Stack):
       rds_freestorage_widget = create_rds_free_storage_space_widget(title='RDS - Free Storage Space', stack=stack, stack_versions=stack_versions)
       repo_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-repo-ec2-instances', [])]
       cpu_repo_widget = create_ec2_cpu_utilization_widget(title="Repo - CPU Utilization", ec2_instance_ids=repo_ec2_ids)
+      cpu_repo_ecs_widget = create_ecs_cpu_widget("Repo Services" {"ServiceName":f"repo-{stack}-{repo_version}"}})
       workers_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-workers-ec2-instances', [])]
       cpu_workers_widget = create_ec2_cpu_utilization_widget(title="Workers - CPU Utilization", ec2_instance_ids=workers_ec2_ids)
+      cpu_workers_ecs_widget = create_ecs_cpu_widget("Worker Services" {"ServiceName":f"repo-{stack}-{workers_version}"}})
       portal_ec2_ids = [s for vp in stack_versions for s in config.get(f'{vp}-portal-ec2-instances', [])]
       cpu_portal_widget = create_ec2_cpu_utilization_widget(title="Portal - CPU Utilization", ec2_instance_ids=portal_ec2_ids)
+      cpu_portal_ecs_widget = create_ecs_cpu_widget("Portal Services" {"ServiceName":f"repo-{stack}-{portal_version}"}})
       network_out_portal_widget = create_ec2_network_out_widget(title="Portal - Network out", ec2_instance_ids=portal_ec2_ids)
+      # TODO create 'network out' widget for portal services
       repo_memory_widget = create_memory_widget(title='Repo - Memory used', config=config, stack_versions=stack_versions, environment='Repository')
       workers_memory_widget = create_memory_widget(title='Workers - Memory used', config=config, stack_versions=stack_versions, environment='Workers')
       workers_jobs_completed_widget = create_worker_stats_widget(title="Workers stats - Jobs completed", config=config, stack_versions=stack_versions, metric_name='Completed Job Count')
       workers_pc_time_widget = create_worker_stats_widget(title="Workers stats - % time running", config=config, stack_versions=stack_versions, metric_name='% Time Running')
       workers_cumulative_time_widget = create_worker_stats_widget(title="Workers stats - Cumulative time", config=config, stack_versions=stack_versions, metric_name='Cumulative runtime')
       repo_alb_rtime_widget2 = create_repo_alb_response_widget_v2(title='Repo ALB response time', config=config, stack_versions=stack_versions)
-      docker_cpu_widget = create_docker_cpu_widget_v2(stack)
-      docker_network_widget = create_docker_network_widget_v2(stack)
+      repo_ecs_alb_rtime_widget2 = create_repo_ecs_alb_response_widget_v2('Repo ECS ALB response time', stack, repo_version)
+      registry_ecs_cpu_widget = create_registry_ecs_cpu_widget_v2(stack)
+      registry_ecs_network_widget = create_registry_ecs_network_widget_v2(stack)
       rds_read_throughput_widget = create_rds_read_throughput_widget(title="RDS Read Throughput", stack=stack, stack_versions=stack_versions)
       rds_write_throughput_widget = create_rds_write_throughput_widget(title="RDS Write Throughput", stack=stack, stack_versions=stack_versions)
       rds_read_latency_widget = create_rds_read_latency_widget(title="RDS Read Latency", stack=stack, stack_versions=stack_versions)
@@ -456,12 +503,16 @@ class SynapseCloudwatchDashboardStack(Stack):
       rds_write_iops_widget = create_rds_write_iops_widget(title="RDS Write Iops", stack=stack, stack_versions=stack_versions)
 
       dashboard.add_widgets(cpu_repo_widget)
+      dashboard.add_widgets(cpu_repo_ecs_widget)
       dashboard.add_widgets(cpu_workers_widget)
+      dashboard.add_widgets(cpu_workers_ecs_widget)
       dashboard.add_widgets(rds_cpu_widget)
       dashboard.add_widgets(rds_freestorage_widget)
       dashboard.add_widgets(cpu_portal_widget)
+      dashboard.add_widgets(cpu_portal_ecs_widget)
       dashboard.add_widgets(network_out_portal_widget)
-      dashboard.add_widgets(docker_cpu_widget, docker_network_widget)
+      # TODO display 'network out' widget for portal services
+      dashboard.add_widgets(registry_ecs_cpu_widget, registry_ecs_network_widget)
       dashboard.add_widgets(repo_memory_widget)
       dashboard.add_widgets(workers_memory_widget)
       dashboard.add_widgets(repo_active_connections_widget)
@@ -471,6 +522,7 @@ class SynapseCloudwatchDashboardStack(Stack):
       dashboard.add_widgets(workers_cumulative_time_widget)
       dashboard.add_widgets(query_perf_widget)
       dashboard.add_widgets(repo_alb_rtime_widget2)
+      dashboard.add_widgets(repo_ecs_alb_rtime_widget2)
       dashboard.add_widgets(ses_widget)
       dashboard.add_widgets(filescanner_widget)
       dashboard.add_widgets(opensearch_widget)

--- a/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
+++ b/synapse_cloudwatch_dashboard/synapse_cloudwatch_dashboard_stack.py
@@ -328,12 +328,13 @@ def create_repo_alb_response_widget_v2(title, config, stack_versions):
 
   return widget
 
+# title: title for the widget
+# stack: dev or prod
+# version_lb_name_map: e.g.: {"582":"app/repo-dev-582-0/d415d054e3532643"}
 def create_repo_ecs_alb_response_widget_v2(title, stack, version_lb_name_map):
   metrics = []
-  print(f"Size of version_lb_name_map is {len(version_lb_name_map)}")
   for stack_version in version_lb_name_map:
     lb_name=version_lb_name_map[stack_version]
-    print(f"For stack version {stack_version}, load balancer name is {lb_name}.")
 
     metric1 = cw.Metric(
       namespace='AWS/ApplicationELB',
@@ -540,6 +541,7 @@ class SynapseCloudwatchDashboardStack(Stack):
       dashboard.add_widgets(rds_read_latency_widget, rds_write_latency_widget)
       dashboard.add_widgets(rds_read_iops_widget, rds_write_iops_widget)
 
+    # Use the CloudWatch client to look up the ECS Task IDs associated with an ECS Service
     def get_ecs_task_ids(self, service_name):
       response = self.cw_client.list_metrics(
         Namespace="ECS/ContainerInsights", 
@@ -552,6 +554,8 @@ class SynapseCloudwatchDashboardStack(Stack):
             result.add(dimension['Value'])
       return result
 
+    # Create the dimensions for ECS metrics, given the stack, service, and version list
+    #
     # stack: dev or prod
     # service: repo, workers, or portal
     # versions: e.g., [582,583]
@@ -569,6 +573,8 @@ class SynapseCloudwatchDashboardStack(Stack):
     			result.append({"dimensions":dimensions, "label":label})
     	return result
 
+    # Look up the Load Balancer names for Synapse stack versions,
+    # returning a map from the latter to the former
     def version_to_lb_name_map(self, service, stack, stack_versions):
       next_token=None
       result = {}


### PR DESCRIPTION
Adapt for ECS and for running from AWS Code Pipeline.
Introduces a `BEANSTALK_MODE` parameter to switch between beanstalk and ECS.
In ECS mode, looks up task Ids and Load Balancer names in CloudWatch.
Allows using the default profile when authenticating with AWS.
